### PR TITLE
Use daemon-thread to avoid blocking shutdown when close is not called

### DIFF
--- a/core/src/main/java/zipkin/reporter/AsyncReporter.java
+++ b/core/src/main/java/zipkin/reporter/AsyncReporter.java
@@ -147,7 +147,7 @@ public abstract class AsyncReporter<S> implements Reporter<S>, Flushable, Compon
       if (messageTimeoutNanos > 0) { // Start a thread that flushes the queue in a loop.
         final BufferNextMessage consumer =
             new BufferNextMessage(sender, messageMaxBytes, messageTimeoutNanos);
-        new Thread(() -> {
+        final Thread flushThread = new Thread(() -> {
           try {
             while (!result.closed.get()) {
               result.flush(consumer);
@@ -156,7 +156,14 @@ public abstract class AsyncReporter<S> implements Reporter<S>, Flushable, Compon
             for (byte[] next : consumer.drain()) result.pending.offer(next);
             result.close.countDown();
           }
-        }, "AsyncReporter(" + sender + ")").start();
+        }, "AsyncReporter(" + sender + ")");
+        flushThread.setDaemon(true);
+        flushThread.start();
+        Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+          if(!result.closed.get()) {
+            result.close();
+          }
+        }));
       }
       return result;
     }


### PR DESCRIPTION
@NegatioN 

It can be difficult to call close on AsyncReporter when the usage-context is unaware of when shutdown is about to happen. If the flusher thread is the only non-daemon thread left, then it should be safe to assume that it is supposed to be stopped too. The current non-daemon thread implementation block shutdown when close isn't called. 

We have a batch-jobs run by cron that hangs due to the current implementation. At the moment we have solved it by using a Shutdownhook with forced exit.
